### PR TITLE
NRE for FromQuery fixed

### DIFF
--- a/src/Unchase.Swashbuckle.AspNetCore.Extensions/Filters/XEnumNamesParameterFilter.cs
+++ b/src/Unchase.Swashbuckle.AspNetCore.Extensions/Filters/XEnumNamesParameterFilter.cs
@@ -8,10 +8,10 @@ namespace Unchase.Swashbuckle.AspNetCore.Extensions.Filters
     {
         public void Apply(IParameter parameter, ParameterFilterContext context)
         {
-            var typeInfo = context.ParameterInfo.ParameterType;
+            var typeInfo = context.ParameterInfo?.ParameterType?? context.PropertyInfo.PropertyType;
             if (typeInfo.IsEnum)
             {
-                var names = Enum.GetNames(context.ParameterInfo.ParameterType);
+                var names = Enum.GetNames(typeInfo);
                 parameter.Extensions.Add("x-enumNames", names);
             }
             else if (typeInfo.IsGenericType && !parameter.Extensions.ContainsKey("x-enumNames"))


### PR DESCRIPTION
Faced with NRE on `Apply` when some class passes as FromQuery param in controller action. Fixed.
```csharp
//controller
[HttpGet]
public IActionResult TestAction([FromQuery]SomeClass some)
 { return Ok(); }
...
//class
public class SomeClass
{  public string Value { get; set; } }
```