### PR TITLE
add "x-enumNames" for schema properties no matter if the type is gene…

### DIFF
--- a/src/Unchase.Swashbuckle.AspNetCore.Extensions/Filters/XEnumNamesSchemaFilter.cs
+++ b/src/Unchase.Swashbuckle.AspNetCore.Extensions/Filters/XEnumNamesSchemaFilter.cs
@@ -59,9 +59,11 @@ namespace Unchase.Swashbuckle.AspNetCore.Extensions.Filters
                         schema.Extensions.Add("x-enumDescriptions", enumsDescriptionsArray);
                     }
                 }
+                return;
             }
+            
             // add "x-enumNames" for schema with generic types
-            else if (typeInfo.IsGenericType && !schema.Extensions.ContainsKey("x-enumNames"))
+            if (typeInfo.IsGenericType && !schema.Extensions.ContainsKey("x-enumNames"))
             {
                 foreach (var genericArgumentType in typeInfo.GetGenericArguments())
                 {
@@ -98,7 +100,8 @@ namespace Unchase.Swashbuckle.AspNetCore.Extensions.Filters
                     }
                 }
             }
-            else if (schema.Properties?.Count > 0)
+            
+            if (schema.Properties?.Count > 0)
             {
                 foreach (var schemaProperty in schema.Properties)
                 {


### PR DESCRIPTION
If the class is generic you must give description not only for generic arguments, but also for its own properties.
For example:
```
/// <summary>
///     API response status
/// </summary>
public enum Status
{
    /// <summary>
    ///     Normal response
    /// </summary>
    Ok,
    /// <summary>
    ///     Some fail
    /// </summary>
    Fail
}

public class ApiResponse<T>
{
    /// <summary>
    ///     API response status
    /// </summary>
    public Status Status { get; set; }

    /// <summary>
    ///     Response data
    /// </summary>
    public T Data { get; set; }
}

//Action attribute 
[ProducesResponseType(StatusCodes.Status201Created, Type = typeof(ApiResponse<SomeClass>))]
```

Before this pull request you will not get description for Status enum property of the ApiResponse<T>