### PR TITLE
fixed schema null object reference

### DIFF
--- a/src/Unchase.Swashbuckle.AspNetCore.Extensions/Filters/DisplayEnumsWithValuesDocumentFilter.cs
+++ b/src/Unchase.Swashbuckle.AspNetCore.Extensions/Filters/DisplayEnumsWithValuesDocumentFilter.cs
@@ -73,7 +73,7 @@ namespace Unchase.Swashbuckle.AspNetCore.Extensions.Filters
                 return;
 
             // add enum descriptions to input parameters of every operation
-            foreach (var parameter in openApiDoc.Paths.Values.SelectMany(v => v.Operations).SelectMany(op => op.Value.Parameters))
+            foreach (var parameter in openApiDoc.Paths.Values.SelectMany(v => v.Operations).SelectMany(op => op.Value.Parameters).Where(p => p.Schema != null))
             {
                 OpenApiSchema schema = null;
                 if (parameter.Schema.Reference == null)


### PR DESCRIPTION
same problem as issue 17
https://github.com/unchase/Unchase.Swashbuckle.AspNetCore.Extensions/issues/17

workaround can be new schema
![image](https://user-images.githubusercontent.com/8721054/136043277-cf643411-0aee-4817-afe5-e4f6e7709745.png)

this commit add filter Schema != null to bypass this problem

