### PR TITLE
Swashbuckle.AspNetCore 6.9.0, fix for inheritdocs

### DIFF
--- a/src/Unchase.Swashbuckle.AspNetCore.Extensions/Filters/InheritDocOperationFilter.cs
+++ b/src/Unchase.Swashbuckle.AspNetCore.Extensions/Filters/InheritDocOperationFilter.cs
@@ -181,19 +181,8 @@ namespace Unchase.Swashbuckle.AspNetCore.Extensions.Filters
                                 {
                                     schema = context.SchemaRepository.Schemas.FirstOrDefault(s => parameter.Schema.AllOf.FirstOrDefault(a => a.Reference.Id == s.Key) != null).Value;
                                 }
-                                else
-                                {
-                                    if (parameter.Description == null)
-                                    {
-                                        parameter.Description = XmlCommentsTextHelper.Humanize(paramNode.InnerXml);
-                                    }
-                                    else if (!parameter.Description.Contains(paramNode.InnerXml))
-                                    {
-                                        parameter.Description += XmlCommentsTextHelper.Humanize(paramNode.InnerXml);
-                                    }
-
-                                    continue;
-                                }
+                                
+                                // paramNode is null, can't use paramNode.InnerXml here (not null check is above)
                             }
                             else
                             {

--- a/src/Unchase.Swashbuckle.AspNetCore.Extensions/Unchase.Swashbuckle.AspNetCore.Extensions.csproj
+++ b/src/Unchase.Swashbuckle.AspNetCore.Extensions/Unchase.Swashbuckle.AspNetCore.Extensions.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.4.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="6.9.0" />
   </ItemGroup>
 
 </Project>

--- a/test/Unchase.Swashbuckle.AspNetCore.Extensions.Tests/Unchase.Swashbuckle.AspNetCore.Extensions.Tests.csproj
+++ b/test/Unchase.Swashbuckle.AspNetCore.Extensions.Tests/Unchase.Swashbuckle.AspNetCore.Extensions.Tests.csproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
-
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -16,9 +15,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.4.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.4.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.9.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Related to #38

1. Upped NuGets (bug is only observable in newest Swashbuckle's releases).
2. Added stinking reflection for acquiring private field `XmlCommentsSchemaFilter._xmlDocMembers`. Don't know a better way w/o proposing modifications in Swashbuckle's API. If its broken in the next Swashbuckle release, then `NotSupportedException` will throw.
3. `XPathDocument` tries to load again for each xml file from the `BaseURI` (usually its `file:///`).
   - If `SwaggerGenOptions.IncludeXmlComments` is called with `string filePath` or `() => new XPathDocument(uri)`, then all is ok.
   - But if user calls something like `new XPathDocument(new StringReader(File.ReadAllText(filePath)))` - it's bad, no inheritdocs will be resolved from that file.
4. Because of the last one, fixed NRE in `InheritDocOperationFilter`, so that swagger will not fail although displaying non-resolved inheritdocs.